### PR TITLE
Verify error

### DIFF
--- a/src/xml/Generic.php
+++ b/src/xml/Generic.php
@@ -331,8 +331,11 @@ class Generic extends XmlCore
 			throw new \Exception("The element local name must be valid");
 		}
 
-		foreach( $this->childNodes as $childNode )
-			$childNode->validateElement();
+        if ( $this->childNodes )
+        {
+		    foreach( $this->childNodes as $childNode )
+			    $childNode->validateElement();
+        }
 	}
 
 	/**

--- a/src/xml/Generic.php
+++ b/src/xml/Generic.php
@@ -331,11 +331,11 @@ class Generic extends XmlCore
 			throw new \Exception("The element local name must be valid");
 		}
 
-        if ( $this->childNodes )
-        {
-		    foreach( $this->childNodes as $childNode )
-			    $childNode->validateElement();
-        }
+		if ( $this->childNodes )
+		{
+			foreach( $this->childNodes as $childNode )
+				$childNode->validateElement();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Hi there, is me again.

Verification process fails when an element has "null" childNodes.

In my case this happens when a SignaturePolicy is added. Iterating SigPolicyQualifier children throws an error because childNodes is null.